### PR TITLE
Hexo Theme Cards 已整合 Artitalk

### DIFF
--- a/docs/doc.md
+++ b/docs/doc.md
@@ -19,6 +19,8 @@ GitHub 仓库：[Artitalk.js](https://github.com/ArtitalkJS/Artitalk)
 
 ### [hexo-theme-volantis](https://github.com/xaoxuu/hexo-theme-volantis/)
 
+### [hexo-theme-cards](https://github.com/ChrAlpha/hexo-theme-cards)
+
 ## 🚀 开始使用
 
 ### 🌈 LeanCloud 的相关准备


### PR DESCRIPTION
从「Cards」v1.1.0 开始，只需要在页面 `front-matter` 中配置 `layout: artitalk`，并将 Artitalk 配置项写入 `artitalk` 字段下便可直接使用。

```yaml
layout: artitalk

artitalk:
  appId: xxx
  appKey: xxxx
  serverURL: http://example.com
```

为了防止 Artitalk 加载阻塞页面，Cards 在加载 Artitalk 时使用 `defer` 关键字异步加载、并通过回调函数进行 Artitlak 初始化。事实上，总共就只需要两行代码。

```html
<div id="artitalk_main"></div>
<script defer src="https://unpkg.com/artitalk" onload="new Artitalk(/* Artitalk Configs */)"></script>
```

For technical reivew, you can refer to [this commit](https://github.com/ChrAlpha/hexo-theme-cards/commit/32351d9dcf04e9c071eb104fd8dd40a8c62f9637)