### PR TITLE
修改成功案例: HiFun Blog

### DIFF
--- a/docs/links.md
+++ b/docs/links.md
@@ -27,7 +27,7 @@ sidebar: auto
 | FMKLI | [说说](https://blog.fmkli.ga/index.php/talk.html) | typecho | [Breeze](https://github.com/GongZhengke/Breeze) |
 | Ender's Blog | [说说](https://code004accepted.github.io/shuoshuo/) | Hexo | [Volantis](https://github.com/volantis-x/hexo-theme-volantis) |
 | 泠汐阁 | [说说](https://blog.qingxu.live/talk/) | Hexo | [Butterfly](https://github.com/jerryc127/hexo-theme-butterfly) |
-| HiFun Blog | [说说](https://hifun.now.sh/talk/) | Hexo | [fluid](https://github.com/fluid-dev/hexo-theme-fluid) |
+| YFun's Blog | [说说](https://www.yfun.top/talk/) | Hexo | [fluid](https://github.com/fluid-dev/hexo-theme-fluid) |
 | Weidows | [⭐ 陈茶酱醋 ⭐](https://weidows.github.io/artitalk/older_artitalk) | Hexo | [Butterfly](https://github.com/jerryc127/hexo-theme-butterfly) |
 
 


### PR DESCRIPTION
`HiFun Blog` 更名为 `YFun’s Blog` 并更换域名。

原 PR: #39 