### PR TITLE
add link: krau's blog

### DIFF
--- a/docs/links.md
+++ b/docs/links.md
@@ -39,6 +39,7 @@ sidebar: auto
 | Dongzhi.| [自言自语](https://xiaocq.top/artitalk/) | Hexo | [Butterfly](https://github.com/jerryc127/hexo-theme-butterfly) |
 | Jason | [说说&日常](https://fictory.cn/artitalk/) | Hexo | [Butterfly](https://github.com/jerryc127/hexo-theme-butterfly) |
 | 洛竹的博客 | [说说](https://youngjuning.js.org/talk/) | Hexo | [Butterfly](https://github.com/jerryc127/hexo-theme-butterfly) |
+| krau's blog | [关于我](https://krau.top/about/) | Valaxy | [Yun](https://github.com/YunYouJun/valaxy/tree/main/packages/valaxy-theme-yun) |
 
 ## 如何加入成功案例
 


### PR DESCRIPTION
添加 krau's blog，这是第一个成功为 valaxy 框架的博客接入 artitalk 的案例 ~~( 因为其他人没做~~